### PR TITLE
Include git_current_branch function to remove OMZ dependancy

### DIFF
--- a/zsh-iterm-touchbar.plugin.zsh
+++ b/zsh-iterm-touchbar.plugin.zsh
@@ -6,6 +6,18 @@ GIT_STASHED="${GIT_STASHED:-$}"
 GIT_UNPULLED="${GIT_UNPULLED:-⇣}"
 GIT_UNPUSHED="${GIT_UNPUSHED:-⇡}"
 
+# Output name of current branch.
+git_current_branch() {
+  local ref
+  ref=$(command git symbolic-ref --quiet HEAD 2> /dev/null)
+  local ret=$?
+  if [[ $ret != 0 ]]; then
+    [[ $ret == 128 ]] && return  # no git repo.
+    ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
+  fi
+  echo ${ref#refs/heads/}
+}
+
 # Uncommitted changes.
 # Check for uncommitted changes in the index.
 git_uncomitted() {

--- a/zsh-iterm-touchbar.plugin.zsh
+++ b/zsh-iterm-touchbar.plugin.zsh
@@ -1,4 +1,5 @@
-pre_cmd() {
+precmd() {
+  autoload -Uz vcs_info
   # Reset Touchbar
   echo -ne "\033]1337;PopKeyLabels\a"
 
@@ -8,7 +9,6 @@ pre_cmd() {
 
   # GIT
   # ---
-  # Check if the current directory is in a Git repository.
   # Check if the current directory is in a Git repository.
   command git rev-parse --is-inside-work-tree &>/dev/null || return
 


### PR DESCRIPTION
The `git_current_branch` function is actually a part of OMZ.  For those of us that don't use OhMyZsh, this needs to be included separately.

🐛 for #1 