### PR TITLE
Increased functionality on current branch button

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Currently it shows:
 
   * F1 - Current directory 👉
-  * F2 - Current git branch 🎋
+  * F2 - Current git branch, press to display all branches and switch between them 🎋
   * F3 - Current git repo status 🔥 / 🙌
     * `+` — uncommitted changes in the index;
     * `!` — unstaged changes;


### PR DESCRIPTION
Now if the user clicks the current branch button, it will show a list of all the branches for that repo and if one is clicked it switches to that branch. Works just like the npm-run button. I would appreciate feedback