### PR TITLE
Yarn support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently it shows:
     * `⇣` — unpulled commits;
     * `⇡` — unpushed commits.
   * F4 - Push to origin branch (git push origin [branch]) ✉️
-  * F5 - Display `npm-run` scripts from `package.json` ⚡️
+  * F5 - Display `npm-run` or `yarn-run` scripts from `package.json` ⚡️ /🐱
 
 ### Requirements
 

--- a/zsh-iterm-touchbar.plugin.zsh
+++ b/zsh-iterm-touchbar.plugin.zsh
@@ -145,7 +145,7 @@ function _displayDefault() {
   if [[ -f package.json ]]; then
       if [[ -f yarn.lock ]]; then
           pecho "\033]1337;SetKeyLabel=F5=🐱 yarn-run\a"
-          bindkey "${fnKeys[5]}" _displayNpmScripts
+          bindkey "${fnKeys[5]}" _displayYarnScripts
       else
           pecho "\033]1337;SetKeyLabel=F5=⚡️ npm-run\a"
           bindkey "${fnKeys[5]}" _displayNpmScripts
@@ -180,7 +180,7 @@ function _displayYarnScripts() {
   # find available yarn run scripts only if new directory
   if [[ $lastPackageJsonPath != $(echo "$(pwd)/package.json") ]]; then
     lastPackageJsonPath=$(echo "$(pwd)/package.json")
-    yarnScripts=($(node -e "console.log(JSON.parse($(yarn run --json).split('\n')[3]).data.items.filter(name => !name.includes(':')).sort((a, b) => a.localeCompare(b)).filter((name, idx) => idx < 12).join(' '))"))
+    yarnScripts=($(node -e "console.log($(yarn run --json 2>&1 | sed '4!d').data.items.filter(name => !name.includes(':')).sort((a, b) => a.localeCompare(b)).filter((name, idx) => idx < 12).join(' '))"))
   fi
 
   _clearTouchbar


### PR DESCRIPTION
Many projects today use yarn (https://yarnpkg.com/) as a replacement for npm. This change will use yarn instead of npm if a `yarn.lock` file is found in the project containing `package.json`.