### PR TITLE
improve node script support

### DIFF
--- a/zsh-iterm-touchbar.plugin.zsh
+++ b/zsh-iterm-touchbar.plugin.zsh
@@ -184,7 +184,7 @@ function _displayYarnScripts() {
   # find available yarn run scripts only if new directory
   if [[ $lastPackageJsonPath != $(echo "$(pwd)/package.json") ]]; then
     lastPackageJsonPath=$(echo "$(pwd)/package.json")
-    yarnScripts=($(node -e "console.log([$(yarn run --json 2>>/dev/null | tr '\n' ',')].find(line => line && line.type === 'list' && line.data && line.data.type === 'possibleCommands').data.items.filter(name => !name.includes(':')).sort((a, b) => a.localeCompare(b)).filter((name, idx) => idx < 12).join(' '))"))
+    yarnScripts=($(node -e "console.log([$(yarn run --json 2>>/dev/null | tr '\n' ',')].find(line => line && line.type === 'list' && line.data && line.data.type === 'possibleCommands').data.items.sort((a, b) => a.localeCompare(b)).filter((name, idx) => idx < 12).join(' '))"))
   fi
 
   _clearTouchbar

--- a/zsh-iterm-touchbar.plugin.zsh
+++ b/zsh-iterm-touchbar.plugin.zsh
@@ -9,6 +9,15 @@ GIT_UNPUSHED="${GIT_UNPUSHED:-⇡}"
 # YARN
 YARN_ENABLED=true
 
+# https://unix.stackexchange.com/a/22215
+find-up () {
+  path=$(pwd)
+  while [[ "$path" != "" && ! -e "$path/$1" ]]; do
+    path=${path%/*}
+  done
+  echo "$path"
+}
+
 # Output name of current branch.
 git_current_branch() {
   local ref
@@ -151,8 +160,8 @@ function _displayDefault() {
 
   # PACKAGE.JSON
   # ------------
-  if [[ -f package.json ]]; then
-      if [[ -f yarn.lock ]] && [[ "$YARN_ENABLED" = true ]]; then
+  if [[ $(find-up package.json) != "" ]]; then
+      if [[ $(find-up yarn.lock) != "" ]] && [[ "$YARN_ENABLED" = true ]]; then
           setKey 6 "🐱 yarn-run" _displayYarnScripts '-q'
       else
           setKey 6 "⚡️ npm-run" _displayNpmScripts '-q'
@@ -162,8 +171,8 @@ function _displayDefault() {
 
 function _displayNpmScripts() {
   # find available npm run scripts only if new directory
-  if [[ $lastPackageJsonPath != $(echo "$(pwd)/package.json") ]]; then
-    lastPackageJsonPath=$(echo "$(pwd)/package.json")
+  if [[ $lastPackageJsonPath != $(find-up package.json) ]]; then
+    lastPackageJsonPath=$(find-up package.json)
     npmScripts=($(node -e "console.log(Object.keys($(npm run --json)).sort((a, b) => a.localeCompare(b)).filter((name, idx) => idx < 19).join(' '))"))
   fi
 
@@ -183,8 +192,8 @@ function _displayNpmScripts() {
 
 function _displayYarnScripts() {
   # find available yarn run scripts only if new directory
-  if [[ $lastPackageJsonPath != $(echo "$(pwd)/package.json") ]]; then
-    lastPackageJsonPath=$(echo "$(pwd)/package.json")
+  if [[ $lastPackageJsonPath != $(find-up package.json) ]]; then
+    lastPackageJsonPath=$(find-up package.json)
     yarnScripts=($(node -e "console.log([$(yarn run --json 2>>/dev/null | tr '\n' ',')].find(line => line && line.type === 'list' && line.data && line.data.type === 'possibleCommands').data.items.sort((a, b) => a.localeCompare(b)).filter((name, idx) => idx < 19).join(' '))"))
   fi
 

--- a/zsh-iterm-touchbar.plugin.zsh
+++ b/zsh-iterm-touchbar.plugin.zsh
@@ -84,7 +84,8 @@ pecho() {
 }
 
 # F1-12: https://github.com/vmalloc/zsh-config/blob/master/extras/function_keys.zsh
-fnKeys=('^[OP' '^[OQ' '^[OR' '^[OS' '^[[15~' '^[[17~' '^[[18~' '^[[19~' '^[[20~' '^[[21~' '^[[23~' '^[[24~')
+# F13-F20: just running read and pressing F13 through F20. F21-24 don't print escape sequences
+fnKeys=('^[OP' '^[OQ' '^[OR' '^[OS' '^[[15~' '^[[17~' '^[[18~' '^[[19~' '^[[20~' '^[[21~' '^[[23~' '^[[24~' '^[[1;2P' '^[[1;2Q' '^[[1;2R' '^[[1;2S' '^[[15;2~' '^[[17;2~' '^[[18;2~' '^[[19;2~')
 touchBarState=''
 npmScripts=()
 gitBranches=()
@@ -163,7 +164,7 @@ function _displayNpmScripts() {
   # find available npm run scripts only if new directory
   if [[ $lastPackageJsonPath != $(echo "$(pwd)/package.json") ]]; then
     lastPackageJsonPath=$(echo "$(pwd)/package.json")
-    npmScripts=($(node -e "console.log(Object.keys($(npm run --json)).filter(name => !name.includes(':')).sort((a, b) => a.localeCompare(b)).filter((name, idx) => idx < 12).join(' '))"))
+    npmScripts=($(node -e "console.log(Object.keys($(npm run --json)).sort((a, b) => a.localeCompare(b)).filter((name, idx) => idx < 19).join(' '))"))
   fi
 
   _clearTouchbar
@@ -184,7 +185,7 @@ function _displayYarnScripts() {
   # find available yarn run scripts only if new directory
   if [[ $lastPackageJsonPath != $(echo "$(pwd)/package.json") ]]; then
     lastPackageJsonPath=$(echo "$(pwd)/package.json")
-    yarnScripts=($(node -e "console.log([$(yarn run --json 2>>/dev/null | tr '\n' ',')].find(line => line && line.type === 'list' && line.data && line.data.type === 'possibleCommands').data.items.sort((a, b) => a.localeCompare(b)).filter((name, idx) => idx < 12).join(' '))"))
+    yarnScripts=($(node -e "console.log([$(yarn run --json 2>>/dev/null | tr '\n' ',')].find(line => line && line.type === 'list' && line.data && line.data.type === 'possibleCommands').data.items.sort((a, b) => a.localeCompare(b)).filter((name, idx) => idx < 19).join(' '))"))
   fi
 
   _clearTouchbar


### PR DESCRIPTION
* remove ":" filtering (it was breaking support for [scripty](https://github.com/testdouble/scripty)).
* expand possible scripts from 11 to 19
* enable node scripts inside subdirectories