### PR TITLE
add env var to disable git key

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ zgen load iam4x/zsh-iterm-touchbar
 
 ### Customize
 
+ENV variables to enable or disable git:
+
+```shell
+TOUCHBAR_GIT_ENABLED=true
+```
 ENV variables for git icons:
 
 ```shell

--- a/zsh-iterm-touchbar.plugin.zsh
+++ b/zsh-iterm-touchbar.plugin.zsh
@@ -8,6 +8,7 @@ GIT_UNPUSHED="${GIT_UNPUSHED:-⇡}"
 
 # YARN
 YARN_ENABLED=true
+TOUCHBAR_GIT_ENABLED=true
 
 # https://unix.stackexchange.com/a/22215
 find-up () {
@@ -136,7 +137,9 @@ function _displayDefault() {
   # GIT
   # ---
   # Check if the current directory is a git repository and not the .git directory
-  if git rev-parse --is-inside-work-tree &>/dev/null && [[ "$(git rev-parse --is-inside-git-dir 2> /dev/null)" == 'false' ]]; then
+  if [[ "$TOUCHBAR_GIT_ENABLED" = true ]] &&
+    git rev-parse --is-inside-work-tree &>/dev/null &&
+    [[ "$(git rev-parse --is-inside-git-dir 2> /dev/null)" == 'false' ]]; then
 
     # Ensure the index is up to date.
     git update-index --really-refresh -q &>/dev/null


### PR DESCRIPTION
I use some pretty large git repos and the shelling out to `git` in this script makes my prompt extremely slow so I added an ENV var to disable it. I named it with the `TOUCHBAR_` because `GIT_ENABLED` and `YARN_ENABLED` might have some unintended conflicts. I'd be happy to open a PR to rename the other variables as well.

I find using zsh's built in `vcs-info` a lot faster than shelling out but I'm not sure exactly how to hook into it with a script like this. Thanks for this project, its great to have this stupid touchscreen doing something useful for once.